### PR TITLE
docs: 明确插件开发中 DConfig appId 使用宿主应用标识

### DIFF
--- a/skills/dde-control-center-development/references/architecture.md
+++ b/skills/dde-control-center-development/references/architecture.md
@@ -106,6 +106,10 @@ PluginBegin
 
 插件加载前检查模块名是否在 `hideModule` 中，若在则跳过加载。DccObject 的只读属性 `visibleToApp` 和 `enabledToApp` 反映了结合配置后的最终状态。
 
+> **注意**：插件使用 DConfig 时，`appId` 必须使用宿主控制中心的正式应用
+> 标识 `org.deepin.dde.control-center`，不要随意构造或套用其他应用的 appId；
+> 配置 ID 才使用插件自身的标识。
+
 ## DBus 接口
 
 - 服务名：`org.deepin.dde.ControlCenter1`

--- a/skills/dde-control-center-development/references/gotchas.md
+++ b/skills/dde-control-center-development/references/gotchas.md
@@ -24,3 +24,4 @@
 - 不要把 `--spec` 当成万能调试开关（框架库需要额外设置）
 - 不要混用 `dde-tray-loader` 的 IID、flags 或消息协议
 - 不要使用 `QSettings` 替代 DConfig（详见 `$dtk-development`）
+- 使用 DConfig 时 `appId` 必须是宿主控制中心的应用标识 `org.deepin.dde.control-center`，不要随意构造

--- a/skills/dde-shell-development/references/design.md
+++ b/skills/dde-shell-development/references/design.md
@@ -96,6 +96,10 @@ config->value("key", defaultVal);
 
 配置元数据在 `configs/<plugin-id>.json`，通过 `dtk_add_config_meta_files` 注册。
 
+> **注意**：DConfig 的 `appId` 必须使用宿主应用 dde-shell 的正式应用标识
+> `org.deepin.dde.shell`，不要随意构造或套用其他应用的 appId；配置 ID
+> 才使用插件自身的 ID。
+
 ## 安装路径
 
 | 内容 | 路径 |

--- a/skills/dde-shell-development/references/gotchas.md
+++ b/skills/dde-shell-development/references/gotchas.md
@@ -28,3 +28,4 @@
 - 不要把 LayerShell 排他区域加给所有窗口
 - 不要忘记 `#include "<文件名>.moc"` 在文件末尾
 - 不要使用 `QSettings` 替代 DConfig（详见 `$dtk-development`）
+- 使用 DConfig 时 `appId` 必须是宿主 dde-shell 的应用标识 `org.deepin.dde.shell`，不要随意构造

--- a/skills/dde-tray-development/references/gotchas.md
+++ b/skills/dde-tray-development/references/gotchas.md
@@ -27,3 +27,4 @@
 - 不要释放 `PluginProxyInterface` 指针
 - 不要使用 `QSystemTrayIcon`（不属于 DDE 托盘插件体系）
 - 不要使用 `QSettings` 替代 DConfig（详见 `$dtk-development`）
+- 使用 DConfig 时 `appId` 必须是宿主 Dock（dde-tray-loader）的应用标识 `org.deepin.ds.dock`，不要随意构造


### PR DESCRIPTION
## 变更说明

在 dde-shell-development、dde-tray-development、dde-control-center-development 三个插件开发 skill 中补充 DConfig 的 appId 使用规范：

- **dde-shell**：appId 必须使用宿主应用标识 `org.deepin.dde.shell`
- **dde-tray-loader（Dock）**：appId 必须使用宿主应用标识 `org.deepin.ds.dock`
- **dde-control-center**：appId 必须使用宿主应用标识 `org.deepin.dde.control-center`

明确：插件开发使用 DConfig 时，`appId` 必须是宿主应用的正式应用标识，不要随意构造或套用其他应用的 appId；只有配置 ID（configId）才使用插件自身的标识。

涉及文件：
- `skills/dde-shell-development/references/design.md`、`gotchas.md`
- `skills/dde-tray-development/references/gotchas.md`
- `skills/dde-control-center-development/references/architecture.md`、`gotchas.md`

## 影响
- 规范插件开发时 DConfig 的 appId 命名，避免配置隔离失效或与应用冲突
- 与 dtk-development 中 DConfig 的 appId 规范保持一致

## Summary by Sourcery

Clarify DConfig appId usage for dde shell, tray, and control center plugins to ensure consistent configuration isolation with host applications.

Documentation:
- Document that dde-shell plugins must use the host appId `org.deepin.dde.shell` when accessing DConfig, using plugin IDs only for config IDs.
- Document that dde-tray (dde-tray-loader/Dock) plugins must use the host appId `org.deepin.ds.dock` for DConfig instead of custom or reused IDs.
- Document that dde-control-center plugins must use the host appId `org.deepin.dde.control-center` for DConfig and reserve plugin identifiers for config IDs.
- Add DConfig appId gotcha notes to each plugin development guide to discourage arbitrary appId construction and align with existing DConfig conventions.